### PR TITLE
ASSETS-28555 : Fix the issue of Selectors not closing on clicking the confirm button

### DIFF
--- a/examples/vanilla-js/index.html
+++ b/examples/vanilla-js/index.html
@@ -73,7 +73,18 @@
          * @function onClose
          */
         function onClose() {
-            const selectorDialog = document.getElementById('asset-selector-dialog') || document.getElementById('destination-selector-dialog');
+            const selectorDialog = document.getElementById('asset-selector-dialog');
+            selectorDialog.close();
+        }
+
+        /**
+         * Closes the Destination Selector dialog when it is called.
+         * This is a helper function used by Asset Selectors UI.
+         *
+         * @function onClose
+         */
+        function destinationSelectorOnClose() {
+            const selectorDialog = document.getElementById('destination-selector-dialog');
             selectorDialog.close();
         }
 
@@ -87,6 +98,18 @@
         function handleSelection(selection) {
             console.log('Selected asset:', selection);
             onClose();
+        };
+
+        /**
+         * Handles the selected path when it is called.
+         * This is a helper function used by Asset Selectors UI.
+         *
+         * @function handleOnConfirm
+         * @param {object} selection - The selected path.
+         */
+        function handleOnConfirm(selection) {
+            console.log('Selected path:', selection);
+            destinationSelectorOnClose();
         };
 
         /**
@@ -160,8 +183,8 @@
 
             /** @type {DestinationSelectorProps} */
             const props = {
-                "onClose": onClose,
-                "handleSelection": handleSelection,
+                "onClose": destinationSelectorOnClose,
+                "handleSelection": handleOnConfirm,
             }
 
             // Get the container element where the Destination Selector will be rendered.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR makes the `DestinationSelector` and `AssetSelector` dialogs to close on clicking the `confirm` or `close` buttons 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
